### PR TITLE
Error Compiling on MacOSx

### DIFF
--- a/src/textio.hpp
+++ b/src/textio.hpp
@@ -98,7 +98,7 @@ inline std::string positionToFen(const Position& pos)
         {
             fen += static_cast<char>('0' + emptySquares);
         }
-        if (rank > 0)
+        if (r > 0)
         {
             fen += '/';
         }


### PR DESCRIPTION
Following Error Recieved, compiling on MacOSx:

./textio.hpp:101:18: error: ordered comparison between pointer and zero ('int
      (*)(Square) noexcept' and 'int')
        if (rank > 0)
            ~~~~ ^ ~
1 error generated.
make: *** [make] Error 1


I also tried changing the line to:
 if (rank > (void*)0)

But this yielded the same error